### PR TITLE
fix: firestore newly added data not shown

### DIFF
--- a/lib/src/firestore_pagination.dart
+++ b/lib/src/firestore_pagination.dart
@@ -247,7 +247,8 @@ class _FirestorePaginationState extends State<FirestorePagination> {
       latestDocQuery = latestDocQuery.endBeforeDocument(_docs.first);
     }
 
-    _liveStreamSub = latestDocQuery.snapshots().listen(
+    _liveStreamSub =
+        latestDocQuery.snapshots(includeMetadataChanges: true).listen(
       (QuerySnapshot snapshot) async {
         await tempSub?.cancel();
         if (snapshot.docs.isEmpty ||


### PR DESCRIPTION
Reason: hasPendingWrites always returns true for non FieldValue data.

For more info, see this comment: https://github.com/OutdatedGuy/firebase_pagination/issues/11#issuecomment-1258013330

fixes #11 