### PR TITLE
fix: docs not loading after first scroll

### DIFF
--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <cloud_firestore/cloud_firestore_plugin_c_api.h>
+#include <firebase_core/firebase_core_plugin_c_api.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  CloudFirestorePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("CloudFirestorePluginCApi"));
+  FirebaseCorePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
 }

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,8 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  cloud_firestore
+  firebase_core
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/lib/src/firestore_pagination.dart
+++ b/lib/src/firestore_pagination.dart
@@ -206,7 +206,7 @@ class _FirestorePaginationState extends State<FirestorePagination> {
       );
 
       _isFetching = false;
-      if (!_isEnded && !isDocRemoved) {
+      if (!isDocRemoved) {
         _isEnded = snapshot.docs.length < docsLimit;
       }
 

--- a/lib/src/realtime_db_pagination.dart
+++ b/lib/src/realtime_db_pagination.dart
@@ -224,7 +224,7 @@ class _RealtimeDBPaginationState extends State<RealtimeDBPagination> {
       final isDataRemoved = snapshot.type == DatabaseEventType.childRemoved;
 
       _isFetching = false;
-      if (!_isEnded && !isDataRemoved) {
+      if (!isDataRemoved) {
         _isEnded = snapshot.snapshot.children.length < docsLimit;
       }
 


### PR DESCRIPTION
## Changes

Setting the isEnded value for each document data load. This prevents the first null data event setting it to `true` forever.

fixes #23, fixes #28