### PR TITLE
return entire snapshot, instead of one doc a time

### DIFF
--- a/example/lib/firestore_pagination_example.dart
+++ b/example/lib/firestore_pagination_example.dart
@@ -40,7 +40,7 @@ class _FirestorePaginationExampleState
                 padding: const EdgeInsets.all(8.0),
                 separatorBuilder: (context, index) => const Divider(),
                 itemBuilder: (context, snapshot, index) {
-                  final msg = snapshot.get('text');
+                  final msg = snapshot[index].get('text');
 
                   return ListTile(
                     shape: RoundedRectangleBorder(

--- a/example/lib/realtimedb_pagination_ascending_example.dart
+++ b/example/lib/realtimedb_pagination_ascending_example.dart
@@ -43,7 +43,7 @@ class _RealtimeDBAscendingPaginationExampleState
                   child: Text('No TODO tasks found!!!'),
                 ),
                 itemBuilder: (context, snapshot, index) {
-                  final msg = snapshot.child('text').value as String?;
+                  final msg = snapshot[index].child('text').value as String?;
 
                   return ListTile(
                     shape: RoundedRectangleBorder(

--- a/example/lib/realtimedb_pagination_descending_example.dart
+++ b/example/lib/realtimedb_pagination_descending_example.dart
@@ -45,7 +45,7 @@ class _RealtimeDBDescendingPaginationExampleState
                   child: Text('No messages found!!!'),
                 ),
                 itemBuilder: (context, snapshot, index) {
-                  final msg = snapshot.child('text').value as String?;
+                  final msg = snapshot[index].child('text').value as String?;
 
                   return ListTile(
                     shape: RoundedRectangleBorder(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -304,10 +304,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: a2662fb1f114f4296cf3f5a50786a2d888268d7776cf681aa17d660ffa23b246
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.0.0"
+    version: "14.2.1"
 sdks:
-  dart: ">=3.3.0-0 <4.0.0"
+  dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -167,6 +167,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.4"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -179,34 +203,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -264,10 +288,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   vector_math:
     dependency: transitive
     description:
@@ -276,14 +300,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      name: vm_service
+      sha256: a2662fb1f114f4296cf3f5a50786a2d888268d7776cf681aa17d660ffa23b246
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "14.0.0"
 sdks:
-  dart: ">=3.2.3 <4.0.0"
-  flutter: ">=3.3.0"
+  dart: ">=3.3.0-0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/firestore_pagination.dart
+++ b/lib/src/firestore_pagination.dart
@@ -74,7 +74,7 @@ class FirestorePagination extends StatefulWidget {
   ///
   /// The builder is passed the build context, snapshot of the document and
   /// index of the item in the list.
-  final Widget Function(BuildContext, DocumentSnapshot, int) itemBuilder;
+  final Widget Function(BuildContext, List<DocumentSnapshot>, int) itemBuilder;
 
   /// The builder to use to render the separator.
   ///

--- a/lib/src/realtime_db_pagination.dart
+++ b/lib/src/realtime_db_pagination.dart
@@ -76,7 +76,7 @@ class RealtimeDBPagination extends StatefulWidget {
   ///
   /// The builder is passed the build context, snapshot of data and index of
   /// the item in the list.
-  final Widget Function(BuildContext, DataSnapshot, int) itemBuilder;
+  final Widget Function(BuildContext, List<DataSnapshot>, int) itemBuilder;
 
   /// The field to use to sort the data. Give the same value as the field
   /// used to order the data in the query.

--- a/lib/src/widgets/views/build_pagination.dart
+++ b/lib/src/widgets/views/build_pagination.dart
@@ -87,7 +87,7 @@ class BuildPagination<T> extends StatelessWidget {
           physics: physics,
           shrinkWrap: shrinkWrap,
           padding: padding,
-          itemCount: 1 + (isLoading ? 1 : 0),
+          itemCount: items.length + (isLoading ? 1 : 0),
           itemBuilder: (BuildContext context, int index) {
             if (index >= items.length) return bottomLoader;
 

--- a/lib/src/widgets/views/build_pagination.dart
+++ b/lib/src/widgets/views/build_pagination.dart
@@ -36,7 +36,7 @@ class BuildPagination<T> extends StatelessWidget {
   final List<T> items;
 
   /// The builder to use to render the items.
-  final Widget Function(BuildContext, T, int) itemBuilder;
+  final Widget Function(BuildContext, List<T>, int) itemBuilder;
 
   /// The builder to use to render the separator.
   ///
@@ -91,7 +91,7 @@ class BuildPagination<T> extends StatelessWidget {
           itemBuilder: (BuildContext context, int index) {
             if (index >= items.length) return bottomLoader;
 
-            return itemBuilder(context, items[index], index);
+            return itemBuilder(context, items, index);
           },
           separatorBuilder: separatorBuilder,
         );
@@ -108,7 +108,7 @@ class BuildPagination<T> extends StatelessWidget {
           itemBuilder: (BuildContext context, int index) {
             if (index >= items.length) return bottomLoader;
 
-            return itemBuilder(context, items[index], index);
+            return itemBuilder(context, items, index);
           },
           gridDelegate: gridDelegate,
         );
@@ -135,7 +135,7 @@ class BuildPagination<T> extends StatelessWidget {
               (int index) {
                 if (index >= items.length) return bottomLoader;
 
-                return itemBuilder(context, items[index], index);
+                return itemBuilder(context, items, index);
               },
             ),
           ),

--- a/lib/src/widgets/views/build_pagination.dart
+++ b/lib/src/widgets/views/build_pagination.dart
@@ -87,7 +87,7 @@ class BuildPagination<T> extends StatelessWidget {
           physics: physics,
           shrinkWrap: shrinkWrap,
           padding: padding,
-          itemCount: items.length + (isLoading ? 1 : 0),
+          itemCount: 1 + (isLoading ? 1 : 0),
           itemBuilder: (BuildContext context, int index) {
             if (index >= items.length) return bottomLoader;
 


### PR DESCRIPTION
As per #47  t's noted that the `itemBuilder` returns the `documentSnapshot` of the document in the given index, which is being iterated on. I'd like to get the list of snapshots from the firebase query, which would help me group the snapshots as per requirements.

This was personal impln of the fork, it's yet pending
 - Tests,
 - Examples, and
 - Manual Optimization to catch excess builds