### PR TITLE
Feat: Added support for onData callback

### DIFF
--- a/lib/src/firestore_pagination.dart
+++ b/lib/src/firestore_pagination.dart
@@ -66,6 +66,7 @@ class FirestorePagination extends StatefulWidget {
     this.padding,
     this.controller,
     this.pageController,
+    this.onData,
   });
 
   /// The query to use to fetch data from Firestore.
@@ -161,6 +162,11 @@ class FirestorePagination extends StatefulWidget {
   /// Defaults to [PageController].
   final PageController? pageController;
 
+  /// Callback for when data is loaded, allows access to loaded data from the parent widget.
+  ///
+  /// Defaults to `null`.
+  final void Function(List<DocumentSnapshot>)? onData;
+
   @override
   State<FirestorePagination> createState() => _FirestorePaginationState();
 }
@@ -221,6 +227,8 @@ class _FirestorePaginationState extends State<FirestorePagination> {
         ..clear()
         ..addAll(snapshot.docs);
 
+      widget.onData?.call(_docs);
+
       // To set new updates listener for the existing data
       // or to set new live listener if the first document is removed.
       final isDocRemoved = snapshot.docChanges.any(
@@ -280,6 +288,8 @@ class _FirestorePaginationState extends State<FirestorePagination> {
         }
 
         _docs.insert(0, snapshot.docs.first);
+
+        widget.onData?.call(_docs);
 
         // To handle newly added data after this curently loaded data.
         await _setLiveListener();


### PR DESCRIPTION
This pull request introduces a new callback feature to the `FirestorePagination` widget, allowing parent widgets to access loaded data, in case someone wants to get this data to another state management tool. The main changes include the addition of the `onData` callback and its invocation at appropriate points in the data loading process.

Key changes:

* Added `onData` callback parameter to `FirestorePagination` widget to allow parent widgets to access loaded data (`lib/src/firestore_pagination.dart`). [[1]](diffhunk://#diff-7de71e930d718a27dd6ac3c7f8c71f739bcf11155baa761039409743e4f67c42R69) [[2]](diffhunk://#diff-7de71e930d718a27dd6ac3c7f8c71f739bcf11155baa761039409743e4f67c42R165-R169)
* Invoked `onData` callback after data is loaded in `_FirestorePaginationState` class to notify parent widgets (`lib/src/firestore_pagination.dart`). [[1]](diffhunk://#diff-7de71e930d718a27dd6ac3c7f8c71f739bcf11155baa761039409743e4f67c42R230-R231) [[2]](diffhunk://#diff-7de71e930d718a27dd6ac3c7f8c71f739bcf11155baa761039409743e4f67c42R292-R293)

## ⚠️ Notes
**Still have to update the real time db and documentation**