### PR TITLE
Feat: Added support for multiple search filters and optional strategy

### DIFF
--- a/.fvm/flutter_sdk
+++ b/.fvm/flutter_sdk
@@ -1,0 +1,1 @@
+/Users/sante/fvm/versions/3.29.2

--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,0 +1,4 @@
+{
+  "flutterSdkVersion": "3.29.2",
+  "flavors": {}
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -268,14 +268,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
-  string_similarity:
-    dependency: transitive
-    description:
-      name: string_similarity
-      sha256: b4b73ec3af3e4203504b136dfbcdbca29edea4eb373684811b76ded9f40a54b9
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.1"
   term_glyph:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -13,34 +13,34 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   cloud_firestore:
     dependency: "direct main"
     description:
@@ -69,18 +69,18 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   firebase_core:
     dependency: "direct main"
     description:
@@ -163,18 +163,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -195,10 +195,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -211,18 +211,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -240,50 +240,50 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
   vector_math:
     dependency: transitive
     description:
@@ -296,10 +296,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:
@@ -309,5 +309,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.6.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.22.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -268,6 +268,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  string_similarity:
+    dependency: transitive
+    description:
+      name: string_similarity
+      sha256: b4b73ec3af3e4203504b136dfbcdbca29edea4eb373684811b76ded9f40a54b9
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   term_glyph:
     dependency: transitive
     description:

--- a/lib/src/firestore_pagination.dart
+++ b/lib/src/firestore_pagination.dart
@@ -7,7 +7,6 @@ import 'package:flutter/scheduler.dart';
 
 // Firebase Packages
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:string_similarity/string_similarity.dart';
 
 // Data Models
 import 'models/filter_model.dart';
@@ -330,14 +329,10 @@ class _FirestorePaginationState extends State<FirestorePagination> {
                       (item.data() as Map<String, dynamic>)[filter.fieldName]
                           ?.toString()
                           .toLowerCase();
-                  if (filter.fuzzySearch) {
-                    return (value?.similarityTo(
-                                filter.searchValue.toLowerCase()) ??
-                            0) >
-                        0.5;
-                  }
-                  return value?.contains(filter.searchValue.toLowerCase()) ??
-                      false;
+                  return value != null && filter.match(
+                    value,
+                    filter.searchValue.toLowerCase(),
+                  );
                 })
                 .toList()
                 .any((it) => it)))

--- a/lib/src/firestore_pagination.dart
+++ b/lib/src/firestore_pagination.dart
@@ -7,6 +7,7 @@ import 'package:flutter/scheduler.dart';
 
 // Firebase Packages
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:string_similarity/string_similarity.dart';
 
 // Data Models
 import 'models/filter_model.dart';
@@ -321,19 +322,27 @@ class _FirestorePaginationState extends State<FirestorePagination> {
 
   @override
   Widget build(BuildContext context) {
-    final filteredDocs = widget.searchFilters.isEmpty
+    final filteredDocs = widget.searchFilters.isNotEmpty
         ? _docs
-        : _docs
             .where((item) => (widget.searchFilters
-                .map((filter) =>
-                    (item.data() as Map<String, dynamic>)[filter.fieldName]
-                        ?.toString()
-                        .toLowerCase()
-                        .contains(filter.searchValue.toLowerCase()) ??
-                    false)
+                .map((filter) {
+                  final value =
+                      (item.data() as Map<String, dynamic>)[filter.fieldName]
+                          ?.toString()
+                          .toLowerCase();
+                  if (filter.fuzzySearch) {
+                    return (value?.similarityTo(
+                                filter.searchValue.toLowerCase()) ??
+                            0) >
+                        0.5;
+                  }
+                  return value?.contains(filter.searchValue.toLowerCase()) ??
+                      false;
+                })
                 .toList()
                 .any((it) => it)))
-            .toList();
+            .toList()
+        : _docs;
     return _isInitialLoading
         ? widget.initialLoader
         : filteredDocs.isEmpty

--- a/lib/src/firestore_pagination.dart
+++ b/lib/src/firestore_pagination.dart
@@ -44,7 +44,7 @@ class FirestorePagination extends StatefulWidget {
   /// Data can be represented in a [ListView], [GridView] or scollable [Wrap].
   const FirestorePagination({
     required this.query,
-    this.searchFilter,
+    this.searchFilters = const [],
     required this.itemBuilder,
     super.key,
     this.separatorBuilder,
@@ -76,7 +76,7 @@ class FirestorePagination extends StatefulWidget {
   final Query query;
 
   /// Filter by substring matching
-  final FilterModel? searchFilter;
+  final List<FilterModel> searchFilters;
 
   /// The builder to use to build the items in the list.
   ///
@@ -321,14 +321,18 @@ class _FirestorePaginationState extends State<FirestorePagination> {
 
   @override
   Widget build(BuildContext context) {
-    final filteredDocs = widget.searchFilter == null
+    final filteredDocs = widget.searchFilters.isEmpty
         ? _docs
         : _docs
-            .where((item) => (item.data()
-                    as Map<String, dynamic>)[widget.searchFilter!.fieldName]
-                .toString()
-                .toLowerCase()
-                .contains(widget.searchFilter!.searchValue.toLowerCase()))
+            .where((item) => (widget.searchFilters
+                .map((filter) =>
+                    (item.data() as Map<String, dynamic>)[filter.fieldName]
+                        ?.toString()
+                        .toLowerCase()
+                        .contains(filter.searchValue.toLowerCase()) ??
+                    false)
+                .toList()
+                .any((it) => it)))
             .toList();
     return _isInitialLoading
         ? widget.initialLoader

--- a/lib/src/models/filter_model.dart
+++ b/lib/src/models/filter_model.dart
@@ -1,11 +1,19 @@
 /// A class for creating a search filter model in [FirestorePagination]
 class FilterModel {
   /// Creates a [FilterModel] object
-  FilterModel({required this.fieldName, required this.searchValue});
+  FilterModel({
+    required this.fieldName,
+    required this.searchValue,
+    this.fuzzySearch = false,
+  });
 
   /// The name of the field in collection to be searched.
   final String fieldName;
 
   /// The substring that is intented to search in [fieldName] value.
   final String searchValue;
+
+  /// If true, the search will be fuzzy, based on the similarity of the strings.
+  /// Uses the package [string_similarity](https://pub.dev/packages/string_similarity).
+  final bool fuzzySearch;
 }

--- a/lib/src/models/filter_model.dart
+++ b/lib/src/models/filter_model.dart
@@ -4,8 +4,10 @@ class FilterModel {
   FilterModel({
     required this.fieldName,
     required this.searchValue,
-    this.fuzzySearch = false,
-  });
+    final bool Function(String, String)? match,
+  }):
+      match = match ?? ((value, search) =>
+          value.toLowerCase().contains(search.toLowerCase()));
 
   /// The name of the field in collection to be searched.
   final String fieldName;
@@ -13,7 +15,8 @@ class FilterModel {
   /// The substring that is intented to search in [fieldName] value.
   final String searchValue;
 
-  /// If true, the search will be fuzzy, based on the similarity of the strings.
-  /// Uses the package [string_similarity](https://pub.dev/packages/string_similarity).
-  final bool fuzzySearch;
+  /// A function to compare [searchValue] with the value of [fieldName].
+  ///
+  /// Defaults to a case-insensitive substring search.
+  bool Function(String, String) match;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ environment:
 dependencies:
   cloud_firestore: ^5.0.0
   firebase_database: ^11.0.0
-  string_similarity: ^2.1.1
   flutter:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   cloud_firestore: ^5.0.0
   firebase_database: ^11.0.0
+  string_similarity: ^2.1.1
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
This PR adds support for a new field in `FilterModel` to allow for different matching strategies. Originally I added the string similarity package as a dependency and used it for a fuzzy search strategy. After some thought, I removed the dependency and added the option to supply your own strategy

Changes to `FirestorePagination` widget:

* [`lib/src/firestore_pagination.dart`](diffhunk://#diff-7de71e930d718a27dd6ac3c7f8c71f739bcf11155baa761039409743e4f67c42L47-R47): Replaced the single `searchFilter` with a list of `searchFilters` to support multiple filters. [[1]](diffhunk://#diff-7de71e930d718a27dd6ac3c7f8c71f739bcf11155baa761039409743e4f67c42L47-R47) [[2]](diffhunk://#diff-7de71e930d718a27dd6ac3c7f8c71f739bcf11155baa761039409743e4f67c42L79-R79)
* [`lib/src/firestore_pagination.dart`](diffhunk://#diff-7de71e930d718a27dd6ac3c7f8c71f739bcf11155baa761039409743e4f67c42L324-R340): Updated the filtering logic in `_FirestorePaginationState` to apply all specified filters.

Changes to `FilterModel`:

* [`lib/src/models/filter_model.dart`](diffhunk://#diff-21211dd3462606cbf9fcd9adb0356693f85b46793f57899bed460e7c8204c55eL4-R21): Added a `match` function to `FilterModel` for customizable filter logic, defaulting to a case-insensitive substring search.

## ⚠️ Notes
**Still have to update the real time db and documentation**